### PR TITLE
Add support for libraries that have subpackages

### DIFF
--- a/.release-notes/7.md
+++ b/.release-notes/7.md
@@ -1,0 +1,11 @@
+## Add support for libraries that have subpackages
+
+Without support for subpackages, libraries like [ponylang/semver](https://github.com/ponylang/semver) wouldn't have their documentation generated.
+
+Semver has a package layout like this:
+
+- semver
+  - semver/range
+  - semver/version
+
+Without support for subpackages, `semver/range` and `semver/version` are removed from the generated documentation because they aren't seen as "being part of the library".


### PR DESCRIPTION
For example, 'semver/range'. Prior to this commit, this action wouldn't
properly handle a library like ponylang/semver.

Closes #5