### PR TITLE
Allow for creating documentation that can link to external dependencies

### DIFF
--- a/.release-notes/8.md
+++ b/.release-notes/8.md
@@ -1,0 +1,12 @@
+## Add support for packages that have external dependencies
+
+Documentation with full linking is now supported for libraries that
+have external dependencies like the `http` package that relies on
+`net_ssl`.
+
+For this to work, a new experimental corral object `packages` must
+be used. Additionally, the newish `documentation_url` that is part of
+the `info` object in `corral.json` is also required.
+
+Full documentation on corral as well as an update to add the `packages`
+object is forthcoming.


### PR DESCRIPTION
This isn't the prettiest of code, nor approachs, but the goal of this
action so far is to get everything working "end-to-end" and then go
back and see what additional support we need in tooling to make the
process less brittle.

The code in this commit makes a lot of assumptions about the layout
of dependencies pulled by corral. It shouldn't be doing that. That
knowledge should be in corral and then we could either:

- use parts of corral as a library from a pony version of this
- have a corral command to get said information dumped in some fashion

or something similar. In the meantime, this works.

As usual, I apologize for my Python. It is what it is.

Closes #3