### PR TITLE
Fix broken Dockerfile build

### DIFF
--- a/.release-notes/pycrypto.md
+++ b/.release-notes/pycrypto.md
@@ -1,0 +1,3 @@
+## Fix broken container build
+
+A transitive python dependency added a new dependency (rustc) that breaks the existing prior configuration.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --update --no-cache \
 
 RUN pip3 install --upgrade pip \
   wheel \
+  cryptography==3.3 \
   gitpython \
   in_place \
   mkdocs \


### PR DESCRIPTION
One of our transitive dependencies (from ponylang mkdocs theme) is
the cryptography package. Because we are on alpine, it gets built from
source. Today they did a release that made rust a dependency to build.

I'm going to "pin us" to 3.3 to avoid that dependency.