### PR TITLE
Don't error out if `generated-documentation` branch doesn't exist

### DIFF
--- a/.release-notes/11.md
+++ b/.release-notes/11.md
@@ -1,0 +1,5 @@
+## Fix failure when `generated-documentation` branch doesn't exist
+
+Originally, the code only worked if it didn't exist. When that was fixed, it
+was accidentally fixed in a way so that it only worked if the branch did exist.
+Third time is the charm, right?

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -10,6 +10,7 @@ import sys
 import git
 import in_place
 import yaml
+from git.exc import GitCommandError
 
 # Output strings for coloring
 
@@ -236,7 +237,14 @@ token  = os.environ['RELEASE_TOKEN']
 remote = 'https://' + token + '@github.com/' + os.environ['GITHUB_REPOSITORY']
 git.remote('add', 'gh-token', remote)
 git.fetch('gh-token')
-git.reset('gh-token/generated-documentation')
+# reset will fail if 'generated-documentation` branch doesn't yet exist. That's
+# fine, it will exist after our push. Just not the error and move on.
+try:
+    git.reset('gh-token/generated-documentation')
+except GitCommandError:
+    print(NOTICE + "Couldn't git reset generated-documentation." + ENDC)
+    print(NOTICE + "This error is expected if the branch doesn't exist yet." \
+      + ENDC)
 
 print(INFO + "Running 'mkdocs gh-deploy'." + ENDC)
 os.chdir(docs_build_dir)


### PR DESCRIPTION
It will exist after our first time. Don't freak out!

Closes #10