### PR TITLE
Allow deploy keys as alternative to access tokens

### DIFF
--- a/.release-notes/13.md
+++ b/.release-notes/13.md
@@ -1,0 +1,3 @@
+## Add support for deploy tokens
+
+Previous versions of the library-documentation-action required the use of a personal access token. With this change, it's also possible to use a [deploy key](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys) instead.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ RUN apk add --update --no-cache \
   libressl \
   libressl-dev \
   make \
+  openssh-client \
   python3 \
   python3-dev \
-  py3-pip \
-  openssh-client
+  py3-pip
 
 RUN pip3 install --upgrade pip \
   gitpython \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apk add --update --no-cache \
   make \
   python3 \
   python3-dev \
-  py3-pip
+  py3-pip \
+  openssh-client
 
 RUN pip3 install --upgrade pip \
   gitpython \

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ jobs:
 
 N.B. The environment variable RELEASE_TOKEN that is required by each step must be a personal access token with public_repo access. You can not use the GITHUB_TOKEN environment variable provided by GitHub's action environment. If you try to use GITHUB_TOKEN, the action will fail when trying to upload the built documentation.
 
+Alternatively, you can use a [Deploy Key](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys) with write access by setting the `DEPLOY_KEY` environment variable.
+
 ## Manually triggering a documentation build and deploy
 
 GitHub has a [`workflow_dispatch`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch) event that provides a button the actions UI to trigger the workflow. You can set up a workflow to respond to a workflow_dispatch if you need to regenerate documentation from the last commit on a given branch without doing a full release.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,33 @@ jobs:
 
 N.B. The environment variable RELEASE_TOKEN that is required by each step must be a personal access token with public_repo access. You can not use the GITHUB_TOKEN environment variable provided by GitHub's action environment. If you try to use GITHUB_TOKEN, the action will fail when trying to upload the built documentation.
 
-Alternatively, you can use a [Deploy Key](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys) with write access by setting the `DEPLOY_KEY` environment variable.
+Alternatively, you can use a [Deploy Key](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys) with write access by setting the `DEPLOY_KEY` environment variable:
+
+```yml
+name: Release
+
+on:
+  push:
+    tags:
+      - \d+.\d+.\d+
+
+jobs:
+  generate-documentation:
+    name: Generate documentation for release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Generate documentation and upload
+        uses: ponylang/library-documentation-action@0.1.5
+        with:
+          site_url: "https://MYORG.github.io/MYLIBRARY/"
+          library_name: "MYLIBRARY"
+          docs_build_dir: "build/MY-LIBRARY-docs"
+          git_user_name: "Ponylang Main Bot"
+          git_user_email: "ponylang.main@gmail.com"
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+```
 
 ## Manually triggering a documentation build and deploy
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -22,10 +22,15 @@ ERROR = '\033[31m'
 INFO = '\033[34m'
 NOTICE = '\033[33m'
 
-deploy_key = os.environ.get('DEPLOY_KEY')
-if not deploy_key and 'RELEASE_TOKEN' not in os.environ:
-    print(f"{ERROR}Either RELEASE_TOKEN or DEPLOY_KEY needs to be set in env. "
-          f"Exiting.{ENDC}")
+if 'DEPLOY_KEY' in os.environ:
+    deploy_key = os.environ['DEPLOY_KEY']
+    token = None
+elif 'RELEASE_TOKEN' in os.environ:
+    deploy_key = None
+    token = os.environ['RELEASE_TOKEN']
+else:
+    print(ERROR + "Either RELEASE_TOKEN or DEPLOY_KEY needs to be set in env. "
+          + "Exiting." + ENDC)
     sys.exit(1)
 
 library_name = os.environ['INPUT_LIBRARY_NAME']
@@ -273,7 +278,6 @@ else:
         """
         yield
 
-    token  = os.environ['RELEASE_TOKEN']
     remote = f'https://{token}@github.com/{os.environ["GITHUB_REPOSITORY"]}'
 git.remote('add', 'gh-token', remote)
 with git_auth():

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -296,6 +296,6 @@ with git_auth():
     rslt = os.system(
         'mkdocs gh-deploy --verbose --clean --remote-name gh-token '
         '--remote-branch generated-documentation')
-if rslt.returncode != 0:
+if rslt != 0:
     print(ERROR + "'mkdocs gh-deploy' failed." + ENDC)
     sys.exit(1)

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -6,7 +6,6 @@ import json
 import os
 import os.path
 import shutil
-import subprocess
 import sys
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile, mkstemp
@@ -289,12 +288,10 @@ with git_auth():
           + ENDC)
 
     print(INFO + "Running 'mkdocs gh-deploy'." + ENDC)
-    # pylint: disable=W1510
-    rslt = subprocess.run(
-        ['mkdocs', 'gh-deploy', '--verbose', '--clean',
-         '--remote-name', 'gh-token',
-         '--remote-branch', 'generated-documentation'],
-        cwd=docs_build_dir)
+    os.chdir(docs_build_dir)
+    rslt = os.system(
+        'mkdocs gh-deploy --verbose --clean --remote-name gh-token '
+        '--remote-branch generated-documentation')
 if rslt.returncode != 0:
     print(ERROR + "'mkdocs gh-deploy' failed." + ENDC)
     sys.exit(1)

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -260,6 +260,8 @@ if deploy_key:
                     os.chmod(ssh_wrapper_path, 0o500)
 
                 identity_file.write(deploy_key.encode('utf-8'))
+                if not deploy_key.endswith("\n"):
+                    identity_file.write("\n")
                 identity_file.flush()
                 os.environ['GIT_SSH'] = ssh_wrapper_path
                 try:


### PR DESCRIPTION
This pull request makes the action also work with deploy keys instead of access tokens. Compared to a personal access token, deploy keys have the advantage that they can be limited to a single repository.