### PR TITLE
Fix variable shadowing in with block

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -175,8 +175,8 @@ if os.path.isdir("_corral"):
             print(NOTICE + "No corral.json in " + dd + "." + ENDC)
             continue
 
-        with open(corral_file, 'r', encoding="utf8") as corral_file:
-            corral_data = json.load(corral_file)
+        with open(corral_file, 'r', encoding="utf8") as corral_fd:
+            corral_data = json.load(corral_fd)
             bundle_documentation_url = ""
             try:
                 bundle_documentation_url = corral_data['info']['documentation_url']


### PR DESCRIPTION
By shadowing `corral_file` inside the `with` block, we're changing its type form a string to a file descriptor.

If we error inside this block, we'll try to print the path of the corral file. Since it's no longer a string at that time, trying to concatenate it with other strings will fail with "TypeError: can only concatenate str (not "_io.TextIOWrapper") to str"

See error: https://github.com/ergl/pony-protobuf/runs/6708413752?check_suite_focus=true#step:4:46, which failed inside the `except` block when trying to read from a corral file without "documentation_url"