### PR TITLE
Fix to work with new versions of git

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -244,6 +244,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git = git.Repo().git
 git.config('--global', 'user.name', os.environ['INPUT_GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['INPUT_GIT_USER_EMAIL'])
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 if deploy_key:
     @contextmanager
     def git_auth():


### PR DESCRIPTION
Git now has a "feature" where it will fail to work if the git
repo directory is owned by a different than user than the
one running commands unless it is explicitly marked as safe.