### PR TITLE
Change Dockerfile to install the required material theme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN apk add --update --no-cache \
 RUN pip3 install --upgrade pip \
   gitpython \
   in_place \
-  mkdocs==1.3.1 \
-  mkdocs-ponylang \
+  mkdocs \
+  mkdocs-material \
   pylint \
   pyyaml
 


### PR DESCRIPTION
This change should only be merged, once https://github.com/ponylang/ponyc/pull/4226 has been merged (and released?).

It adapts the docker image to install the required material theme for mkdocs.