### PR TITLE
Stop pushing new images to DockerHub

### DIFF
--- a/.github/workflows/update-release-image.yml
+++ b/.github/workflows/update-release-image.yml
@@ -13,11 +13,6 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,10 @@ IMAGE := ponylang/library-documentation-action
 all: build
 
 build:
-	docker build --pull -t "${IMAGE}:release" .
-	docker build --pull -t "${IMAGE}:latest" .
 	docker build --pull -t "ghcr.io/${IMAGE}:release" .
 	docker build --pull -t "ghcr.io/${IMAGE}:latest" .
 
 push: build
-	docker push "${IMAGE}:release"
-	docker push "${IMAGE}:latest"
 	docker push "ghcr.io/${IMAGE}:release"
 	docker push "ghcr.io/${IMAGE}:latest"
 


### PR DESCRIPTION
We've transitioned to using GitHub Container Registry.