### PR TITLE
Add missing permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,9 @@ concurrency:
   group: pr-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  packages: read
+
 jobs:
   lint-entrypoint-py:
     name: Lint entrypoint.py

--- a/.github/workflows/update-release-image.yml
+++ b/.github/workflows/update-release-image.yml
@@ -6,6 +6,9 @@ on:
       - ponyc-nightly-image-pushed
       - ponyc-release-image-pushed
 
+permissions:
+  packages: write
+
 jobs:
   rebuild-docker-images:
     name: Rebuild docker images


### PR DESCRIPTION
Adds explicit permissions blocks to workflows that were missing them, matching the standard permissions used across ponylang projects.